### PR TITLE
Rename const variable to SIGN_IN_RESULT_CODE

### DIFF
--- a/app/src/main/java/com/example/android/firebaseui_login_sample/MainFragment.kt
+++ b/app/src/main/java/com/example/android/firebaseui_login_sample/MainFragment.kt
@@ -68,7 +68,7 @@ class MainFragment : Fragment() {
     override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
         super.onActivityResult(requestCode, resultCode, data)
         // TODO Listen to the result of the sign in process by filter for when
-        //  SIGN_IN_REQUEST_CODE is passed back. Start by having log statements to know
+        //  SIGN_IN_RESULT_CODE is passed back. Start by having log statements to know
         //  whether the user has signed in successfully
     }
 


### PR DESCRIPTION
The starter and finished code use a const variable `SIGN_IN_RESULT_CODE`. However this variable is incorrectly named as `SIGN_IN_REQUEST_CODE` in comments.

The [**Codelabs tutorial task 6: Implement the login button**](https://codelabs.developers.google.com/codelabs/advanced-android-kotlin-training-login/index.html?index=..%2F..advanced-android-kotlin-training#5) also used the name `SIGN_IN_REQUEST_CODE`. This should also be changed by maintainers.

Fixes #5 and #9